### PR TITLE
fixes breaktime image sometimes affecting other mods

### DIFF
--- a/Breaktime/Imager.cs
+++ b/Breaktime/Imager.cs
@@ -29,7 +29,7 @@ namespace Enhancements.Breaktime
             rectTransform.sizeDelta = new Vector2(100, 50);
 
             _panelLeft = new GameObject("Imager").AddComponent<Image>();
-            _panelLeft.material = CustomUI.Utilities.UIUtilities.NoGlowMaterial;
+            _panelLeft.material = new Material(CustomUI.Utilities.UIUtilities.NoGlowMaterial);
             _panelLeft.rectTransform.SetParent(_imageCanvas.transform, false);
             _panelLeft.rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
             _panelLeft.rectTransform.anchorMax = new Vector2(0.5f, 0.5f);


### PR DESCRIPTION
While watching streams and working on my mod, I noticed that sometimes, some elements of my UI would disappear (specifically, the dividers).
_Before:_
![before](https://user-images.githubusercontent.com/14931856/64286453-5d1c2f80-cf12-11e9-9afe-03cb55e2a47d.PNG)
_After:_
![after](https://user-images.githubusercontent.com/14931856/64286498-7329f000-cf12-11e9-80b3-0e1344211974.PNG)

It turns out that playing a song that has a long enough delay in the middle of it to trigger Breaktime would cause this issue. I identified it to be that [this line](https://github.com/chrislee0419/Enhancements/blob/fd2a6633eb8638b2765db6a0be566f5144ac4df7/Breaktime/Imager.cs#L50) that changed the opacity of the shared no glow material object.

So, ezpz fix is to just copy the material and modify that instead of using the shared material.